### PR TITLE
Fixed two problems causing compilation failure and runtime failure.

### DIFF
--- a/cyarma/cyarma.pyx
+++ b/cyarma/cyarma.pyx
@@ -114,7 +114,7 @@ cdef extern from "armadillo" namespace "arma" nogil:
 ##### Tools to convert numpy arrays to armadillo arrays ######
 cdef mat * numpy_to_mat(np.ndarray[np.double_t, ndim=2] X):
     if not X.flags.f_contiguous:
-        X = X.copy(order="F")
+        X = X.copy("F")
     cdef mat *aR  = new mat(<double*> X.data, X.shape[0], X.shape[1], False, True)
     return aR
 

--- a/example/example/example.pyx
+++ b/example/example/example.pyx
@@ -5,9 +5,9 @@ include "cyarma.pyx"
 
 def example(np.ndarray[np.double_t, ndim=2] X):
 
-    cdef mat aX = numpy_to_mat(X)
+    cdef mat *aX = numpy_to_mat(X)
 
-    cdef mat XX = aX.t() * aX
+    cdef mat XX = aX.t() * cython.operator.dereference(aX)
     cdef mat ch = chol(XX)
     ch.raw_print()
     print np.linalg.cholesky(np.dot(X.T,X))


### PR DESCRIPTION
1. numpy.array.copy(order='F') shows runtime error. Changed it to copy('F')
2. numpy_to_mat_pointer returns mat *. 
   But in the example.pyx, we wrote:
   mat aX = numpy_to_mat(X)
   which caused compilation error. I fixed that. 
