### PR TITLE
Add .save(filename) to #mat

### DIFF
--- a/cyarma/cyarma.pyx
+++ b/cyarma/cyarma.pyx
@@ -48,6 +48,8 @@ cdef extern from "armadillo" namespace "arma" nogil:
         mat operator-(double) nogil
         mat operator+(double) nogil
         mat operator/(double) nogil
+        # input/output
+        mat save(char*)
         #etc
 
     cdef cppclass cube:


### PR DESCRIPTION
By default it saves the matrix under the "arma_binary" format.

Just a simple addition that's very useful :+1: 

EDIT: looks like `.save()` returns a `bool`, gonna update the PR